### PR TITLE
Update moose.gemspec

### DIFF
--- a/moose.gemspec
+++ b/moose.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.executables   = ["moose"]
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.11"


### PR DESCRIPTION
Rubymine does not like the `spec.files.grep(%r{^exe/}).map{ |f| File.basename(f) }`
